### PR TITLE
Handle tilde expansion

### DIFF
--- a/scripts/cronwrap3
+++ b/scripts/cronwrap3
@@ -172,6 +172,7 @@ class Command:
 
         t_start = time.time()
 
+        os.putenv('PATH', os.path.expanduser(os.environ['PATH']))
         self.returncode = os.system(f"( {command} ) > {outfile} 2> {errfile}") >> 8
         self.run_time = time.time() - t_start
         self.stdout = open(outfile, "r").read().strip()


### PR DESCRIPTION
Vixie Cron (standard on Debian based distros) does not expand environment variables. Hence having `PATH=$HOME/bin:$PATH` will NOT work if you try to invoke something in `$HOME/bin`. It does however do tilde expansion, so `PATH=~/bin:$PATH` _does_ work.

Unfortunately, tilde expansion is a shell extension that is not POSIX compatible, but still very much common and expected to work. This small change makes cronwrap3 work well with PATHs using tilde expansion in the PATH used by the os.system() call. Ex: `~some-user/scripts` will become `/home/some-user/scripts` on Linux and probably something else on other platforms.

EDIT:
could alternatively run [expandvars](https://www.geeksforgeeks.org/python-os-path-expandvars-method/) on the command itself, but that does not scratch any itch I have been feeling.